### PR TITLE
cer_issuer getter returning casted binary data

### DIFF
--- a/cfdiclient/fiel.py
+++ b/cfdiclient/fiel.py
@@ -40,16 +40,8 @@ class Fiel():
     def cer_issuer(self):
         # Extraer issuer
         d = self.cer.get_issuer().get_components()
-        # Generar cafena issuer
-        datos = ''
-        for t in d:
-            datos += '{}={},'.format(t[0], t[1])
-
-        datos = datos[:-1]
-        try:
-            return datos.decode('utf8')
-        except AttributeError:
-            return datos
+        # Generar cadena issuer
+        return ','.join(['{key}={value}'.format(key=key.decode(), value=value.decode()) for key, value in d])
 
     def cer_serial_number(self):
         # Obtener numero de serie del certificado


### PR DESCRIPTION
cer.get_issuer().get_components() returns binary tuples which must be decoded before joining them into a single string. This patch first decodes the key and value issuer into a list of strings, then join such list with a comma.